### PR TITLE
improve: display image as max-width in iOS 15+

### DIFF
--- a/Sources/UserDefaultsBrowser/View/RowView.swift
+++ b/Sources/UserDefaultsBrowser/View/RowView.swift
@@ -179,13 +179,21 @@ struct RowView: View {
                     Link(url.absoluteString, destination: url)
 
                 case let .image(uiImage):
-                    if uiImage.size.width < 200 {
+                    //
+                    // ⚠️ Display is corrupted with iOS 14. (SwiftUI bug, maybe)
+                    //
+                    if #available(iOS 15, *) {
                         Image(uiImage: uiImage)
+                            .original(or: .fit)
                     } else {
-                        Image(uiImage: uiImage)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 200)
+                        if uiImage.size.width < 200 {
+                            Image(uiImage: uiImage)
+                        } else {
+                            Image(uiImage: uiImage)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 200)
+                        }
                     }
 
                 case let .data(text):


### PR DESCRIPTION
| iOS 14+ | iOS 15+ |
| -- | -- |
| <img width="392" alt="image" src="https://user-images.githubusercontent.com/2990285/167974945-b0af65c3-bfbf-4de7-baa9-642da5b8f7bf.png"> | <img width="389" alt="image" src="https://user-images.githubusercontent.com/2990285/167974968-6bf49a06-6ce9-4628-8198-0eae0aa36e31.png"> |