### PR TITLE
Use system color for default accent color

### DIFF
--- a/Sources/UserDefaultsBrowser/UIKit/EntryPoint.swift
+++ b/Sources/UserDefaultsBrowser/UIKit/EntryPoint.swift
@@ -16,7 +16,7 @@ private let overlayWindowSize = CGSize(width: 44, height: 44)
 public func setupUserDefaultsBrowserLauncher(
     suiteNames: [String] = [],
     excludeKeys: @escaping (String) -> Bool = { _ in false },
-    accentColor: UIColor = .blue,
+    accentColor: UIColor = .systemBlue,
     imageName: String = "externaldrive",
     displayStyle: DisplayStyle = .sheet
 ) {


### PR DESCRIPTION
Thanks for creating awesome tool 😃 

I tried UserDefaultsBrowser in my app, and noticed that UIKit version's accent color is a little bit hard to see in dark mode when used with default configuration. So I replaced the default accent color by system color to improve visibility especially in dark mode.

| before | after |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-12 at 21 09 58](https://user-images.githubusercontent.com/22269397/168072662-b5a54b63-a302-47e9-b6ff-5ff8c76778f4.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-12 at 21 10 08](https://user-images.githubusercontent.com/22269397/168072767-57f3e9ec-d328-478d-b063-9a3f79f0fbd3.png) |