### PR TITLE
Add CI build of Example project

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,20 @@
+name: Build Examples
+
+on:
+  pull_request
+
+jobs:
+  build-examples:
+    runs-on: macos-12
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        scheme: ['Example (iOS)', 'UIKitApp']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        run: xcodebuild -project Example/Example.xcodeproj -scheme "${{ matrix.scheme }}" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13,OS=latest'

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -16,5 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: build
-        run: xcodebuild -project Example/Example.xcodeproj -scheme "${{ matrix.scheme }}" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13,OS=latest'
+      - name: SwiftPM cache
+        uses: actions/cache@v3
+        with:
+          path: SourcePackages
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('**/Package.resolved') }}
+      - name: Build
+        run: xcodebuild -project Example/Example.xcodeproj -scheme "${{ matrix.scheme }}" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13,OS=latest' -clonedSourcePackagesDirPath SourcePackages


### PR DESCRIPTION
close #17 

As mentioned in #17, it's nice to make sure that public api of this package is not broken by building Example project for every PR. I added workflow to build both SwiftUI / UIKit versions of example apps.

It might be better if comprehensive tests for the package is added and executed on CI, but for now I think simply building Example project as CI is good idea.

I confirmed that this workflows works in my forked repository.
https://github.com/maiyama18/UserDefaultsBrowser/actions/runs/2319719282