### PR TITLE
Update Package.resolved & .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## MacOS
+.DS_Store
+
 ## User settings
 xcuserdata/
 

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -62,6 +62,15 @@
         "revision" : "65b8a439c9e499aebb838c0418c72f7d0e66c6ae",
         "version" : "1.3.0"
       }
+    },
+    {
+      "identity" : "swiftui-common",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/YusukeHosonuma/SwiftUI-Common.git",
+      "state" : {
+        "revision" : "8e2672dbb3fea32d78236fc6048874718119307b",
+        "version" : "1.0.0"
+      }
     }
   ],
   "version" : 2


### PR DESCRIPTION
Two minor fixes 😃 

## 1. Update `Package.resolved` https://github.com/YusukeHosonuma/UserDefaultsBrowser/commit/cac35d6ff6fed3dd4ca9ad8cfd69495a1fb05171

When I build Example project, the diff for `SwiftUI-Common` is generated on `Package.resolved`. So I just committed the diff.

## 2. Update `.gitignore` https://github.com/YusukeHosonuma/UserDefaultsBrowser/commit/66ef8810730495a925858dbff2474c4051cd1888

`.DS_Store` was removed from `.gitignore` in https://github.com/YusukeHosonuma/UserDefaultsBrowser/pull/18. It is a little troublesome to make sure not to commit my local `.DS_Store` every time. Though this issue can be handled by approach like global `.gitignore`, I think it is not bad to re-add `.DS_Store` to `.gitignore`. 